### PR TITLE
maint: use hatch-deps-selector

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,6 +2,7 @@
 schema_version: 1
 
 context:
+  name: jupyter-book
   version: "2.0.2"
   python_check_max: "3.14"
   nodejs_min: "20"
@@ -11,16 +12,16 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/j/jupyter-book/jupyter_book-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/jupyter_book-${{ version }}.tar.gz
   sha256: 36e1428ad85a70e500513793edff3be83c4f036f80eb67bb909180914f50094b
-  patches:
-    - 0000-no-nodeenv.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
-    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+    env:
+      JUPYTER_BOOK_PACKAGE_VARIANT: conda-forge
+      content: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
   python:
     entry_points:
       - jupyter-book = jupyter_book.__main__:main


### PR DESCRIPTION
This PR leans in to the dependency selector that let's us avoid patching upstream.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
